### PR TITLE
Add terminal-notifier hooks for Claude Code input/confirmation waiting

### DIFF
--- a/private_dot_config/claude/hooks/executable_notification-hook.sh
+++ b/private_dot_config/claude/hooks/executable_notification-hook.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Claude Code Notification hook: notify when waiting for user confirmation
+
+input=$(cat)
+message=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('message', '確認が必要です'))" 2>/dev/null || echo "確認が必要です")
+
+terminal-notifier \
+  -title "Claude Code" \
+  -message "$message" \
+  -sound default \
+  -group "claude-code-notification"

--- a/private_dot_config/claude/hooks/executable_stop-hook.sh
+++ b/private_dot_config/claude/hooks/executable_stop-hook.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Claude Code Stop hook: notify when waiting for user input
+
+input=$(cat)
+stop_hook_active=$(echo "$input" | python3 -c "import sys,json; print(json.load(sys.stdin).get('stop_hook_active', False))" 2>/dev/null)
+
+# stop_hook_active が True のときは別の hook がすでに動いているので通知しない
+if [ "$stop_hook_active" != "True" ]; then
+  terminal-notifier \
+    -title "Claude Code" \
+    -message "入力待ちです" \
+    -sound default \
+    -group "claude-code-stop"
+fi

--- a/private_dot_config/claude/settings.json
+++ b/private_dot_config/claude/settings.json
@@ -7,6 +7,27 @@
       "id": "jdtls-lsp",
       "enabled": true
     }
-  ]
+  ],
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.config/claude/hooks/stop-hook.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.config/claude/hooks/notification-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
 }
-


### PR DESCRIPTION
- Stop hook: notify via terminal-notifier when Claude Code finishes responding and waits for user input
- Notification hook: notify with message content when Claude Code sends a notification (e.g. waiting for tool confirmation)
- Hook scripts deployed to ~/.config/claude/hooks/ via chezmoi

https://claude.ai/code/session_0135Z5U6LJbEqkPHup1z5Fnc