### PR TITLE
move yabai/skhd service start from script to Brewfile

### DIFF
--- a/.chezmoiscripts/run_once_after_install-plugins.sh
+++ b/.chezmoiscripts/run_once_after_install-plugins.sh
@@ -12,12 +12,13 @@ asdf plugin add python
 asdf plugin add golang
 asdf install nodejs 18.17.0
 asdf install nodejs 20.18.1
-set -e
-asdf install
 
 # claude code plugins
 claude plugin install jdtls-lsp
 claude plugin install code-review
 claude plugin install pr-review-toolkit
+set -e
+
+asdf install
 
 

--- a/.chezmoiscripts/run_once_after_install-plugins.sh
+++ b/.chezmoiscripts/run_once_after_install-plugins.sh
@@ -20,7 +20,4 @@ claude plugin install jdtls-lsp
 claude plugin install code-review
 claude plugin install pr-review-toolkit
 
-# start background service
-yabai --start-service
-skhd --start-service
 

--- a/bizBrewfile
+++ b/bizBrewfile
@@ -69,8 +69,8 @@ cask "maccy"
 cask "stats"
 
 # Window managment utils
-brew "yabai"
-brew "skhd"
+brew "yabai", restart_service: :changed
+brew "skhd", restart_service: :changed
 brew "borders"
 
 # communication tools

--- a/privateBrewfile
+++ b/privateBrewfile
@@ -67,8 +67,8 @@ cask "karabiner-elements"
 cask "stats"
 
 # Window managment utils
-brew "yabai"
-brew "skhd"
+brew "yabai", restart_service: :changed
+brew "skhd", restart_service: :changed
 brew "borders"
 cask "homerow"
 


### PR DESCRIPTION
Replace `yabai --start-service` and `skhd --start-service` in
run_once_after_install-plugins.sh with `restart_service: :changed`
in Brewfile to make service startup idempotent and managed by
brew bundle natively.

https://claude.ai/code/session_01KvbFhWFQfd1tbH6jaG2Ror