### PR TITLE
fix: use cask instead of brew for docker/tap/sbx in bizBrewfile

### DIFF
--- a/bizBrewfile
+++ b/bizBrewfile
@@ -17,7 +17,7 @@ brew "gcc"
 cask "docker-desktop"
 brew "docker-compose"
 brew "docker"
-brew "docker/tap/sbx"
+cask "docker/tap/sbx"
 
 # git
 brew "diff-so-fancy"


### PR DESCRIPTION
sbx is a cask (GUI app), not a formula. Align with privateBrewfile.

https://claude.ai/code/session_01MiFjx51jXcLQr5STHTfMyB