### PR TITLE
git: narrow URL rewrite rule to own repos only

### DIFF
--- a/private_dot_config/git/config.tmpl
+++ b/private_dot_config/git/config.tmpl
@@ -19,8 +19,8 @@
 [pull]
     ff = only
 
-[url "https://{{.git.user}}@github.com/"]
-    insteadOf = https://github.com/
+[url "https://{{.git.user}}@github.com/{{.git.user}}/"]
+    insteadOf = https://github.com/{{.git.user}}/
 [user]
     name =  {{.git.user}}
     email = {{.git.email}}


### PR DESCRIPTION
Replace the catch-all `insteadOf = https://github.com/` with a
user-scoped rule `insteadOf = https://github.com/<user>/` so that
only the user's own repositories get the username-prefixed HTTPS URL
(forcing authentication), while other public repositories are accessed
without auth.

https://claude.ai/code/session_012No73Lbbt9d1ezHg3ejbBc