### PR TITLE
fix(ci): chezmoi がローカルの feature ブランチコードを使うよう修正

### DIFF
--- a/.github/workflows/install_test.yml
+++ b/.github/workflows/install_test.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Install chezmoi
         run: brew install chezmoi
       - name: Install dotfiles
-        run: chezmoi init --apply https://nakahararuu@github.com/nakahararuu/dotfiles.git
+        run: chezmoi init --apply "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -29,6 +29,6 @@ jobs:
       - name: Install chezmoi
         run: brew install chezmoi
       - name: Install dotfiles
-        run: chezmoi init --apply https://nakahararuu@github.com/nakahararuu/dotfiles.git
+        run: chezmoi init --apply "$GITHUB_WORKSPACE"
       - uses: mxschmitt/action-tmate@v3
 


### PR DESCRIPTION
chezmoi init --apply に GitHub URL を指定していたため、
CI が常に master (デフォルトブランチ) のコードをテストしていた。
$GITHUB_WORKSPACE を指定することで、checkout 済みのブランチのコードを使うよう修正。

https://claude.ai/code/session_01HdL4WaDwMT93Lt7TdYbWhR